### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-manifest-ml[all]==0.1.9
+manifest-ml[all]==0.1.8
 pandas>=2.0.0
 sqlalchemy<2.0.0
 transformers>=4.29.0


### PR DESCRIPTION
There's no manifest-ml version 0.1.9 on the PyPi Package repository resulting in an error when installing the requirements.txt.

This fixes the issue